### PR TITLE
RND-45534: Fix incomplete shut down when websocket connection is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJDIR := obj
 OBJS := $(SRCS:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 BINDIR := bin
 LIBNAME := verbit_streaming
-SWVER := 1.1.1
+SWVER := 1.1.2
 LIBSO := 1
 LIBVER := $(LIBSO).1
 ALIB := $(OBJDIR)/lib$(LIBNAME).a

--- a/deb/verbit-streaming_control_bionic
+++ b/deb/verbit-streaming_control_bionic
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.1-1+bionic
+Version: 1.1.2-1+bionic
 Section: base
 Priority: optional
 Architecture: amd64

--- a/deb/verbit-streaming_control_focal
+++ b/deb/verbit-streaming_control_focal
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.1-1+focal
+Version: 1.1.2-1+focal
 Section: base
 Priority: optional
 Architecture: amd64

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -540,6 +540,11 @@ void WebSocketStreamingClient::on_close(websocketpp::connection_hdl hdl)
 		// setting _error_code causes run_stream() to return false
 		_error_code = ec.value();
 	}
+
+	// Stop the io_service object's event processing loop.
+	// This ensures that the call to _ws_endpoint.run() returns.
+	// See comments in /usr/local/include/boost/asio/io_service.hpp.
+	_ws_endpoint.stop();
 }
 
 bool WebSocketStreamingClient::on_ping(websocketpp::connection_hdl hdl, std::string msg) {


### PR DESCRIPTION
Here is the one line change to harden the closing the websocket to ensure the io_service task execution loop will be shut down and _ws_endpoint.run() will return.

We are testing this overnight with 32 back-to-back 15 minute events in a sequence.  We will check the log of every `alog_1` file to see that the streaming C++ SDK closed the websocket cleanly.