### PR TITLE
Additional Pylon connect resilience

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This project uses [Semantic Versioning](http://semver.org/).
 
+## [1.1.4](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.4) (2026-02-05)
+
+- Make ping keepalive time configurable from default 30s
+
 ## [1.1.3](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.3) (2026-01-23)
 
 - Automatically retry WebSocket connection a few times, after failure (resilience)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This project uses [Semantic Versioning](http://semver.org/).
 
+## [1.1.3](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.3) (2026-01-23)
+
+- Automatically retry WebSocket connection a few times, after failure (resilience)
+
 ## [1.1.1](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.1) (2024-03-18)
 
 - Adjust timeout for shutdown at end of stream to 15s

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This project uses [Semantic Versioning](http://semver.org/).
 ## [1.1.4](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.4) (2026-02-05)
 
 - Make ping keepalive time configurable from default 30s
+- Reset keepalive time on receipt of caption response, in addition to ping (resilience)
 
 ## [1.1.3](https://github.com/verbit-ai/verbit-streaming-cpp-sdk/releases/tag/v1.1.3) (2026-01-23)
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJDIR := obj
 OBJS := $(SRCS:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 BINDIR := bin
 LIBNAME := verbit_streaming
-SWVER := 1.1.2
+SWVER := 1.1.3
 LIBSO := 1
 LIBVER := $(LIBSO).1
 ALIB := $(OBJDIR)/lib$(LIBNAME).a

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJDIR := obj
 OBJS := $(SRCS:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 BINDIR := bin
 LIBNAME := verbit_streaming
-SWVER := 1.1.3
+SWVER := 1.1.4
 LIBSO := 1
 LIBVER := $(LIBSO).1
 ALIB := $(OBJDIR)/lib$(LIBNAME).a

--- a/deb/verbit-streaming_control_bionic
+++ b/deb/verbit-streaming_control_bionic
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.3-1+bionic
+Version: 1.1.4-1+bionic
 Section: base
 Priority: optional
 Architecture: amd64

--- a/deb/verbit-streaming_control_bionic
+++ b/deb/verbit-streaming_control_bionic
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.2-1+bionic
+Version: 1.1.3-1+bionic
 Section: base
 Priority: optional
 Architecture: amd64

--- a/deb/verbit-streaming_control_focal
+++ b/deb/verbit-streaming_control_focal
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.2-1+focal
+Version: 1.1.3-1+focal
 Section: base
 Priority: optional
 Architecture: amd64

--- a/deb/verbit-streaming_control_focal
+++ b/deb/verbit-streaming_control_focal
@@ -1,5 +1,5 @@
 Package: verbit-streaming
-Version: 1.1.3-1+focal
+Version: 1.1.4-1+focal
 Section: base
 Priority: optional
 Architecture: amd64

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -262,7 +262,7 @@ void WebSocketStreamingClient::run_media()
 				std::stringstream media_ss;
 				media_ss << "sent chunk " << chunk.length() << " bytes" <<
 					" get_buffered_amount() " << _ws_con->get_buffered_amount() <<
-					" have sent " << wssc_bytes_sent << " bytes" << std::endl;
+					" have sent " << wssc_bytes_sent << " bytes";
 				write_alog("media", media_ss.str());
 				wssc_report_at_bytes += 500000L;
 			}
@@ -270,7 +270,7 @@ void WebSocketStreamingClient::run_media()
 #if defined(VERBOSE_DEBUG)
 			std::stringstream media_ss;
 			media_ss << "sent chunk " << chunk.length() << " bytes" <<
-				" get_buffered_amount() " << _ws_con->get_buffered_amount() << std::endl;
+				" get_buffered_amount() " << _ws_con->get_buffered_amount();
 			write_alog("media", media_ss.str());
 #endif
 		}
@@ -536,6 +536,8 @@ void WebSocketStreamingClient::on_message(websocketpp::connection_hdl hdl, wspp_
 		+ " frame_type " + _frame_type_str(msg->get_opcode(), msg->get_compressed(), msg->get_fin())
 		+ " payload_len " + std::to_string(payload_len);
 	write_alog("WebSocket", debug);
+
+	update_keepalive();
 
 	// parse message JSON and deliver to handler
 	nlohmann::json message = nlohmann::json::parse(msg->get_payload());

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -334,16 +334,20 @@ void WebSocketStreamingClient::run_media()
 
 void WebSocketStreamingClient::run_keepalive()
 {
-	static const int KEEPALIVE_TIMEOUT_SECONDS = 30;
+	int keepalive_timeout_seconds = 30;
+	char *env_ptr = getenv("VERBIT_KEEPALIVE_SECONDS");
+	if (env_ptr != nullptr) {
+		keepalive_timeout_seconds = atoi(env_ptr);
+	}
 
 	while (!_state.is_final() ) {
 		std::unique_lock<std::mutex> lock(_keepalive_mutex);
 		std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-		if (now > (_keepalive_time + std::chrono::seconds(KEEPALIVE_TIMEOUT_SECONDS))) {
+		if (now > (_keepalive_time + std::chrono::seconds(keepalive_timeout_seconds))) {
 			// _keepalive_time was not updated recently
 			_error_code = KEEPALIVE_TIMEOUT;
 			lock.unlock();
-			write_alog("run_keepalive", "no pings received for " + std::to_string(KEEPALIVE_TIMEOUT_SECONDS) +"s");
+			write_alog("run_keepalive", "no pings received for " + std::to_string(keepalive_timeout_seconds) +"s");
 			stop_stream();
 			break;
 		}

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -337,7 +337,10 @@ void WebSocketStreamingClient::run_keepalive()
 	int keepalive_timeout_seconds = 30;
 	char *env_ptr = getenv("VERBIT_KEEPALIVE_SECONDS");
 	if (env_ptr != nullptr) {
-		keepalive_timeout_seconds = atoi(env_ptr);
+		int env_i = atoi(env_ptr);
+		if (env_i > 0) {
+			keepalive_timeout_seconds = atoi(env_ptr);
+		}
 	}
 
 	while (!_state.is_final() ) {

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -339,7 +339,7 @@ void WebSocketStreamingClient::run_keepalive()
 	if (env_ptr != nullptr) {
 		int env_i = atoi(env_ptr);
 		if (env_i > 0) {
-			keepalive_timeout_seconds = atoi(env_ptr);
+			keepalive_timeout_seconds = env_i;
 		}
 	}
 

--- a/src/verbit/streaming/ws_streaming_client.cpp
+++ b/src/verbit/streaming/ws_streaming_client.cpp
@@ -444,7 +444,11 @@ void WebSocketStreamingClient::on_fail(websocketpp::connection_hdl hdl)
 		}
 	}
 
-	_state.change_if(ServiceState::state_fail, ServiceState::state_opening, true);
+	// "If `stop_stream()` is called during the retry phase (either by the keepalive thread timing out
+	// or by explicit user call), the state becomes `state_closing`." So here we transform either case
+	// to `state_fail`.
+	_state.change_if(ServiceState::state_fail, ServiceState::state_opening, false);
+	_state.change_if(ServiceState::state_fail, ServiceState::state_closing, false);
 
 	wspp_client::connection_ptr con = _ws_endpoint.get_con_from_hdl(hdl);
 

--- a/src/verbit/streaming/ws_streaming_client.h
+++ b/src/verbit/streaming/ws_streaming_client.h
@@ -58,12 +58,12 @@ public:
 	/// Return the WebSocket complete URL (with parameters).
 	const std::string ws_full_url();
 
-	/// Return the number of seconds to retry connecting to the WebSocket server before giving up.
-	/// Retry uses random exponential backoff.
+	/// Return the number of seconds for the **initial** WebSocket connect retry backoff.
+	/// Retry uses a backoff time that is a multiple of this value (`max_` is a misnomer).
 	constexpr double max_connection_retry_seconds() { return _max_conn_retry; }
 
-	/// Set the number of seconds to retry connecting to the WebSocket server before giving up.
-	/// Retry uses random exponential backoff.
+	/// Set the number of seconds for the **initial** WebSocket connect retry backoff.
+	/// Retry uses a backoff time that is a multiple of this value (`max_` is a misnomer).
 	void max_connection_retry_seconds(double seconds) { _max_conn_retry = seconds; }
 
 	/// Return the SSL certificate verification behavior.

--- a/src/verbit/streaming/ws_streaming_client.h
+++ b/src/verbit/streaming/ws_streaming_client.h
@@ -13,7 +13,7 @@
 #include <verbit/streaming/version.h>
 
 #define WSSC_DEFAULT_WS_URL "wss://speech.verbit.co/ws"
-#define WSSC_DEFAULT_CONNECTION_RETRY_SECONDS 60.0
+#define WSSC_DEFAULT_CONNECTION_RETRY_SECONDS 0.4
 
 namespace verbit {
 namespace streaming {
@@ -34,6 +34,7 @@ public:
 	static constexpr const int WS_1006 = 1006;
 	static constexpr const int AUDIO_SOURCE_EOF = 3500;
 	static constexpr const int KEEPALIVE_TIMEOUT = 3510;
+	static constexpr const double MAX_RETRY_SECONDS = 2.5;
 
 	/// Construct a new streaming client.
 	///

--- a/test/test_server.cpp
+++ b/test/test_server.cpp
@@ -16,6 +16,7 @@
 #define LATENCY 250
 //#define ATMOSPHERICS
 //#define NO_LABELS
+//#define INT_SPEAKER_ID
 
 typedef websocketpp::server<websocketpp::config::asio_tls> wspp_server;
 typedef websocketpp::config::asio::message_type::ptr wspp_message_ptr;
@@ -188,7 +189,15 @@ std::string response_items(std::string transcript, std::string speaker_id)
 			r_items += std::string("{\"kind\":\"text\",");
 		}
 		r_items += (std::string("\"value\":\"") + word + "\",");
+#ifdef INT_SPEAKER_ID
+		if (speaker_id.empty()) {
+			r_items += (std::string("\"speaker_id\":0,"));
+		} else {
+			r_items += (std::string("\"speaker_id\":\"") + speaker_id + "\",");
+		}
+#else
 		r_items += (std::string("\"speaker_id\":\"") + speaker_id + "\",");
+#endif
 		char tstr[128];
 		sprintf(tstr, "%.3f", start_t);
 		r_items += (std::string("\"start\":") + tstr + ",");
@@ -229,7 +238,11 @@ std::string response_json(bool eos, std::string lang)
 	} else if ((seen_bytes % 288000) < 198000) {
 		speaker_uuid = "c6eb6f2b-f85b-478f-af8a-a21b00000002";
 	} else {
+#ifdef INT_SPEAKER_ID
+		speaker_uuid = "";
+#else
 		speaker_uuid = "c6eb6f2b-f85b-478f-af8a-a21b00000003";
+#endif
 	}
 #else
 	speaker_uuid = "c6eb6f2b-f85b-478f-af8a-a21b00000001";
@@ -257,11 +270,19 @@ std::string response_json(bool eos, std::string lang)
 #ifndef NO_LABELS
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000001\",\"label\":\"First Host\"}," +
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000002\",\"label\":\"Second Host\"}," +
+#ifdef INT_SPEAKER_ID
+		"{\"id\":0,\"label\":\"\"}" +
+#else
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000003\",\"label\":\"Speaker 3\"}" +  // unidentified
+#endif
 #else
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000001\",\"label\":\"\"}," +
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000002\",\"label\":\"\"}," +
+#ifdef INT_SPEAKER_ID
+		"{\"id\":0,\"label\":\"\"}" +
+#else
 		"{\"id\":\"c6eb6f2b-f85b-478f-af8a-a21b00000003\",\"label\":\"\"}" +
+#endif
 #endif
 		"]," +
 		"\"alternatives\":[{" +


### PR DESCRIPTION
This has changes from:
1. (RND-63530) WebsocketStreamingClient resilience: retry after Pylon WS connect fail
2. (RND-64361) Additional Pylon connect resilience in C++ Verbit Streaming SDK

It includes all the changes from C++ SDK v1.1.3 and v1.1.4 (the latter being the new latest version number) — see the `CHANGES.md` file. It does **not** change the shared object interface or `SOVER` and is compatible with code compiled for the earlier v1.1.2 version.

The notable improvements are:
1. If the WebSocket connection to Pylon does not succeed (_e.g._ returns a non-200 HTTP status, or a WebSocket code like 1006 or 2), the SDK will automatically retry the WS connect, several times in quick succession with some backoff. Only if it can't succeed after several retries in a few seconds, will it return the failure to the caller.
2. An incoming caption response is treated the same as an incoming ping, for purposes of the keepalive logic. Only if no ping **and** no caption response has been received, within the last N seconds, will the keepalive logic trigger.
3. The keepalive time (default 30 seconds) is now tunable via the environment variable `VERBIT_KEEPALIVE_SECONDS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection/retry and keepalive timing behavior, which can affect stream startup reliability and shutdown/timeout behavior under network failures.
> 
> **Overview**
> Improves `WebSocketStreamingClient` resilience by automatically re-queuing failed initial WebSocket connects with a short backoff loop (default initial retry delay reduced to `0.4s`, retrying up to ~`2.5s` total) and ensuring retries stop cleanly if the client is no longer in `state_opening`.
> 
> Makes keepalive less trigger-happy by treating any incoming service message as keepalive activity (not just ping) and allowing the keepalive timeout (default `30s`) to be overridden via `VERBIT_KEEPALIVE_SECONDS`.
> 
> Bumps release/package versions to `1.1.4` and extends the test server to simulate intermittent connect failures and richer caption/translation-like responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e29b36ffa7f75f2f2629ebd5e4d4c725d1c576d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->